### PR TITLE
change openssl version to match nodejs20, fix broken link

### DIFF
--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -14,9 +14,9 @@ endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO openssl/openssl
-    REF "openssl-${VERSION}"
-    SHA512 5a821aaaaa89027ce08a347e5fc216757c2971e29f7d24792609378c54f657839b3775bf639e7330b28b4f96ef0d32869f0a96afcb25c8a2e1c2fe51a6eb4aa3
+    REPO magaya-dev/openssl
+    REF "openssl-${VERSION}+quic"
+    SHA512 fdf8eadce1dc72f621b33ddf2fe5f754882f0b5dd1fd748d1719fb7c0596d5d903f48b088a02995600e8d8b63934082f21df8446ae4d8d2509190ad4bafaa948
     PATCHES
         windows/install-layout.patch
         windows/install-pdbs.patch

--- a/scripts/cmake/vcpkg_find_acquire_program.cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program.cmake
@@ -529,7 +529,7 @@ function(vcpkg_find_acquire_program program)
         elseif(CMAKE_HOST_WIN32)
             if(NOT EXISTS "${PKGCONFIG}")
                 set(VERSION 0.29.2-3)
-                set(program_version git-9.0.0.6373.5be8fcd83-1)
+                set(program_version git-10.0.0.r216.gca58fc56b-1)
                 vcpkg_acquire_msys(
                     PKGCONFIG_ROOT
                     NO_DEFAULT_PACKAGES
@@ -537,7 +537,7 @@ function(vcpkg_find_acquire_program program)
                         "https://repo.msys2.org/mingw/i686/mingw-w64-i686-pkg-config-${VERSION}-any.pkg.tar.zst"
                         0c086bf306b6a18988cc982b3c3828c4d922a1b60fd24e17c3bead4e296ee6de48ce148bc6f9214af98be6a86cb39c37003d2dcb6561800fdf7d0d1028cf73a4
                         "https://repo.msys2.org/mingw/i686/mingw-w64-i686-libwinpthread-${program_version}-any.pkg.tar.zst"
-                        c89c27b5afe4cf5fdaaa354544f070c45ace5e9d2f2ebb4b956a148f61681f050e67976894e6f52e42e708dadbf730fee176ac9add3c9864c21249034c342810
+                        5cd1b3b54d5f8dcba466ebf3154d966d4a8ba497fe09f17603e161d7b9946a3f9d217238ecea192e649e0bc8f723f7661ace9e62631cec8b2e27151570ef52cc
                 )
             endif()
             set("${program}" "${PKGCONFIG_ROOT}/mingw32/bin/pkg-config.exe" CACHE INTERNAL "")


### PR DESCRIPTION
change openssl version to match nodejs20
- nodejs uses a fork of openssl to support QUIC
- changed openssl repo in vckpg to use magaya-dev/openssl

fix broken link
- site hosting libwinpthread no longer lists version git-9.0.0.6373.5be8fcd83-1
- changed to version git-10.0.0.r216.gca58fc56b-1 which is hosted on the site
